### PR TITLE
Fix default rules merging on extension startup

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -113,8 +113,19 @@ chrome.alarms.onAlarm.addListener((alarm) => {
   }
 });
 
-// Cleanup on startup
-chrome.runtime.onStartup.addListener(() => {
+// Cleanup on startup and merge new default patterns
+chrome.runtime.onStartup.addListener(async () => {
+  // Merge new default patterns if any
+  const result = await chrome.storage.sync.get('domainConfig');
+  if (result.domainConfig) {
+    const mergedConfig = mergeConfigs(result.domainConfig, DEFAULT_CONFIG);
+    // Only update if there are new patterns
+    if (mergedConfig.length > result.domainConfig.length) {
+      await chrome.storage.sync.set({ domainConfig: mergedConfig });
+      console.log('✅ Added new default patterns on startup');
+    }
+  }
+
   cleanupOldEntries();
 });
 


### PR DESCRIPTION
## Summary
- Fixed issue where new default categorization rules were not loaded for existing users
- Added logic to merge new default patterns on browser startup, not just extension updates

## Problem
Previously, new default patterns were only merged when the extension was updated (`chrome.runtime.onInstalled` with `reason === 'update'`). This meant users who didn't update the extension wouldn't get new default rules.

## Solution
Added the same merging logic to `chrome.runtime.onStartup` event, which fires when:
- Chrome starts
- The extension is enabled
- The extension is reloaded

This ensures users always have the latest default categorization rules.

## Test Plan
- [ ] Install extension with some patterns
- [ ] Add new patterns to DEFAULT_CONFIG
- [ ] Restart Chrome
- [ ] Verify new patterns are automatically added to user's config
- [ ] Verify existing custom patterns are preserved

🤖 Generated with [Claude Code](https://claude.ai/code)