### PR TITLE
Add video platform patterns

### DIFF
--- a/src/config/default.ts
+++ b/src/config/default.ts
@@ -56,6 +56,13 @@ export const DEFAULT_CONFIG: DomainConfig = [
   { pattern: 'https://x.com/*', category: '🐦 Browsed Social Media' },
   { pattern: 'https://twitter.com/*', category: '🐦 Browsed Social Media' },
 
+  // Video patterns
+  { pattern: 'https://www.youtube.com/watch*', category: '📺 Watched Video' },
+  { pattern: 'https://youtu.be/*', category: '📺 Watched Video' },
+  { pattern: 'https://www.nicovideo.jp/watch/*', category: '📺 Watched Video' },
+  { pattern: 'https://vimeo.com/*', category: '📺 Watched Video' },
+  { pattern: 'https://www.twitch.tv/*', category: '📺 Watched Video' },
+
   // Ignored patterns
   { pattern: 'https://duckduckgo.com/*', category: '🚫 Ignored' }
 ];


### PR DESCRIPTION
## Summary
Added default categorization patterns for popular video platforms with category "📺 Watched Video"

## Patterns Added
- `https://www.youtube.com/watch*` - YouTube videos
- `https://youtu.be/*` - YouTube short URLs
- `https://www.nicovideo.jp/watch/*` - Niconico videos
- `https://vimeo.com/*` - Vimeo videos
- `https://www.twitch.tv/*` - Twitch streams/videos

## Test Plan
- [ ] Visit YouTube video URLs like https://www.youtube.com/watch?v=qWOSznGFpSI
- [ ] Verify they are categorized as "📺 Watched Video"
- [ ] Test short YouTube URLs (youtu.be)
- [ ] Test other video platforms

🤖 Generated with [Claude Code](https://claude.ai/code)