### PR TITLE
fix: move useEffect before early return in UnknownEntries

### DIFF
--- a/src/components/UnknownEntries.tsx
+++ b/src/components/UnknownEntries.tsx
@@ -35,11 +35,7 @@ export const UnknownEntries: FunctionalComponent<UnknownEntriesProps> = ({
   const [isExpanded, setIsExpanded] = useState(false);
   const [existingCategories, setExistingCategories] = useState<string[]>([]);
 
-  if (entries.length === 0) {
-    return null;
-  }
-
-  // Load existing categories on mount
+  // Load existing categories on mount (must be before early return to follow Rules of Hooks)
   useEffect(() => {
     const loadExistingCategories = async () => {
       const result = await chrome.storage.sync.get('domainConfig');
@@ -49,6 +45,10 @@ export const UnknownEntries: FunctionalComponent<UnknownEntriesProps> = ({
     };
     loadExistingCategories();
   }, []);
+
+  if (entries.length === 0) {
+    return null;
+  }
 
   // Handle category input change and show suggestions
   const handleCategoryInput = (value: string) => {


### PR DESCRIPTION
## Summary
- `UnknownEntries.tsx` で `useEffect` が条件による早期 `return null` の**後**に記述されており、Preact/React の Rules of Hooks に違反していた
- `entries.length` が 0 ↔ 非0 と変わるたびに Hook の呼び出し順が変わり "Hook order changed" エラーが発生する
- `useEffect` を早期 return の前に移動して修正

## Test plan
- [ ] エントリが0件 → 非0件 に変化しても "Hook order changed" エラーが出ないことを確認
- [ ] カテゴリ一覧が正常にロードされることを確認
- [ ] ビルドが通ること: `npm run build`
- [ ] テストが通ること: `npm run test:run`