### PR TITLE
fix: avoid TransactionInactiveError in recategorizeAllEntries

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -72,36 +72,40 @@ async function recategorizeAllEntries() {
   const result = await chrome.storage.sync.get('domainConfig');
   const config: DomainConfig = result.domainConfig || DEFAULT_CONFIG;
 
-  // Get all entries
-  const tx = db.transaction('activity', 'readwrite');
-  const store = tx.objectStore('activity');
-
-  const getAllReq = store.getAll();
-  const allEntries = await new Promise<ActivityEntry[]>((resolve) => {
-    getAllReq.onsuccess = () => resolve(getAllReq.result);
+  // Read all entries in one transaction, then close it before awaiting
+  const allEntries = await new Promise<ActivityEntry[]>((resolve, reject) => {
+    const tx = db.transaction('activity', 'readonly');
+    const req = tx.objectStore('activity').getAll();
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
   });
 
   console.log(`📊 Recategorizing ${allEntries.length} entries...`);
 
-  // Update each entry with new category
-  for (const entry of allEntries) {
+  const toUpdate = allEntries.filter((entry) => {
     const { category } = categorizePage(entry.url, config);
+    return entry.category !== category;
+  });
 
-    // Update if category changed
-    if (entry.category !== category) {
-      const updatedEntry = {
-        ...entry,
-        category
-      };
-
-      await new Promise((resolve) => {
-        const putReq = store.put(updatedEntry);
-        putReq.onsuccess = () => resolve(true);
-      });
-    }
+  if (toUpdate.length === 0) {
+    console.log('✅ Recategorization complete (no changes needed)');
+    return;
   }
 
-  console.log('✅ Recategorization complete');
+  // Write all updates in a single new transaction (no await inside)
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction('activity', 'readwrite');
+    const store = tx.objectStore('activity');
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+
+    for (const entry of toUpdate) {
+      const { category } = categorizePage(entry.url, config);
+      store.put({ ...entry, category });
+    }
+  });
+
+  console.log(`✅ Recategorization complete (${toUpdate.length} entries updated)`);
 }
 
 // Run cleanup daily


### PR DESCRIPTION
## Summary
- `recategorizeAllEntries` で `getAll()` の後に `await` を挟んでから同一トランザクションで `put()` を呼んでいたため、IndexedDB の auto-commit により `TransactionInactiveError` が発生していた
- 修正: readonly トランザクションでエントリを全件取得 → 変更対象を抽出 → 新しい readwrite トランザクションで一括 put（内部に await なし）の 2 段構成に変更
- 変更が不要な場合は write トランザクションを開かないため効率も向上

## Test plan
- [ ] カテゴリパターンを追加した後に再分類が正常に完了することを確認
- [ ] DevTools コンソールに `TransactionInactiveError` が出ないことを確認
- [ ] ビルドが通ること: `npm run build`
- [ ] テストが通ること: `npm run test:run`