### PR TITLE
fix: preserve firstSeenAt from existing record on page re-visits

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -170,22 +170,31 @@ chrome.runtime.onMessage.addListener(
       openDatabase().then((db) => {
         const tx = db.transaction('activity', 'readwrite');
         const store = tx.objectStore('activity');
-
         const now = new Date().toISOString();
-        const entry: ActivityEntry = {
-          url: message.entry.url,
-          title: message.entry.title,
-          category: message.entry.category,
-          bodyText: message.entry.bodyText || '',
-          firstSeenAt: message.entry.firstSeenAt || now,
-          updatedAt: now
-        };
 
-        const req = store.put(entry);
-        req.onsuccess = () => {
-          sendResponse({ status: 'ok' });
+        // Read existing entry first to preserve firstSeenAt on re-visits
+        const getReq = store.get(message.entry.url);
+        getReq.onsuccess = () => {
+          const existing: ActivityEntry | undefined = getReq.result;
+          const entry: ActivityEntry = {
+            url: message.entry.url,
+            title: message.entry.title,
+            category: message.entry.category,
+            bodyText: message.entry.bodyText || '',
+            firstSeenAt: existing?.firstSeenAt ?? now,
+            updatedAt: now
+          };
+
+          const putReq = store.put(entry);
+          putReq.onsuccess = () => {
+            sendResponse({ status: 'ok' });
+          };
+          putReq.onerror = (e: Event) => {
+            const error = (e.target as IDBRequest).error;
+            sendResponse({ status: 'error', error });
+          };
         };
-        req.onerror = (e: Event) => {
+        getReq.onerror = (e: Event) => {
           const error = (e.target as IDBRequest).error;
           sendResponse({ status: 'error', error });
         };


### PR DESCRIPTION
## Summary
- `content.ts` は `firstSeenAt` をエントリに含めないため、`background.ts` の `message.entry.firstSeenAt || now` は常に現在時刻になっていた
- さらに `store.put()` は既存レコードを丸ごと上書きするため、再訪問のたびに初回閲覧日時がリセットされていた
- 修正: `log-activity` ハンドラ内で `store.get()` を先に呼び、同一トランザクション内のコールバックで既存の `firstSeenAt` を引き継いでから `put()` するように変更

## Test plan
- [ ] 同一URLに複数回アクセスしても `firstSeenAt` が最初の訪問時刻のまま変わらないことを確認
- [ ] 新規URLの場合は `firstSeenAt` が現在時刻で記録されることを確認
- [ ] ビルドが通ること: `npm run build`
- [ ] テストが通ること: `npm run test:run`