### PR TITLE
Fix Biome useHtmlLang lint error in dashboard.html

### DIFF
--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <title>HistoryLens Dashboard</title>


### PR DESCRIPTION
## Summary
- `src/dashboard.html` の `<html>` タグに `lang="en"` 属性を追加
- Biome v2 の新しいルール `lint/a11y/useHtmlLang` に対応

## 背景
PR #18 (Biome v2.4.15 アップデート) と PR #22 で CI が失敗していた原因。Biome v2 で `useHtmlLang` ルールが追加され、`<html>` タグに `lang` 属性がないとエラーになる。

## Test plan
- [ ] CI (biome) が通ることを確認