### PR TITLE
Hide future dates in weekly view

### DIFF
--- a/src/components/WeeklyReport.tsx
+++ b/src/components/WeeklyReport.tsx
@@ -104,14 +104,20 @@ export const WeeklyReport: FunctionalComponent = () => {
         <button type="button" onClick={() => setWeekOffset(weekOffset - 1)}>
           ← Previous Week
         </button>
-        <button type="button" onClick={() => setWeekOffset(weekOffset + 1)}>
+        <button
+          type="button"
+          onClick={() => setWeekOffset(weekOffset + 1)}
+          disabled={weekOffset >= 0}
+        >
           Next Week →
         </button>
       </div>
       <div id="weeklyLogs">
-        {logsByDay.map(({ dateStr, weekday, grouped }) => (
-          <DaySection key={dateStr} dateStr={dateStr} weekday={weekday} grouped={grouped} />
-        ))}
+        {logsByDay
+          .filter(({ dateStr }) => dateStr <= format(new Date(), 'yyyy-MM-dd'))
+          .map(({ dateStr, weekday, grouped }) => (
+            <DaySection key={dateStr} dateStr={dateStr} weekday={weekday} grouped={grouped} />
+          ))}
       </div>
       {unknownEntries.length > 0 && (
         <UnknownEntries entries={unknownEntries} onCategorized={handleCategorized} />


### PR DESCRIPTION
## Summary

- Weekly viewで未来の日付に `(No records)` が表示されてしまう問題を修正
- 今日以降の日付はフィルタして非表示にする
- 「Next Week」ボタンは現在週以降では無効化してナビゲーションを制限

## Test plan

- [ ] 今週の Weekly view を開いて、今日より未来の曜日が表示されないことを確認
- [ ] 「Next Week →」ボタンが今週では disabled になることを確認
- [ ] 過去の週には全7日分が表示されることを確認