### PR TITLE
Stop using Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
-}


### PR DESCRIPTION
## Summary
- Remove `renovate.json` to stop Renovate from opening dependency update PRs.
- Dependabot security updates stay enabled at the repository level, which matches the desired low-maintenance cadence for this project.

## Follow-up (manual)
Renovate is a GitHub App, so deleting the config alone is not enough — it may open an onboarding PR again. Remove this repository from the Renovate App installation:
https://github.com/settings/installations

## Test plan
- `npm run format` / `npm run lint` / `npm run build` / `npm run test` all pass (config-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)